### PR TITLE
finished shape model and migration

### DIFF
--- a/api/lib/api/design.ex
+++ b/api/lib/api/design.ex
@@ -1,0 +1,104 @@
+defmodule Api.Design do
+  @moduledoc """
+  The Design context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Api.Repo
+
+  alias Api.Design.Shape
+
+  @doc """
+  Returns the list of shapes.
+
+  ## Examples
+
+      iex> list_shapes()
+      [%Shape{}, ...]
+
+  """
+  def list_shapes do
+    Repo.all(Shape)
+  end
+
+  @doc """
+  Gets a single shape.
+
+  Raises `Ecto.NoResultsError` if the Shape does not exist.
+
+  ## Examples
+
+      iex> get_shape!(123)
+      %Shape{}
+
+      iex> get_shape!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_shape!(id), do: Repo.get!(Shape, id)
+
+  @doc """
+  Creates a shape.
+
+  ## Examples
+
+      iex> create_shape(%{field: value})
+      {:ok, %Shape{}}
+
+      iex> create_shape(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_shape(attrs \\ %{}) do
+    %Shape{}
+    |> Shape.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a shape.
+
+  ## Examples
+
+      iex> update_shape(shape, %{field: new_value})
+      {:ok, %Shape{}}
+
+      iex> update_shape(shape, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_shape(%Shape{} = shape, attrs) do
+    shape
+    |> Shape.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a shape.
+
+  ## Examples
+
+      iex> delete_shape(shape)
+      {:ok, %Shape{}}
+
+      iex> delete_shape(shape)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_shape(%Shape{} = shape) do
+    Repo.delete(shape)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking shape changes.
+
+  ## Examples
+
+      iex> change_shape(shape)
+      %Ecto.Changeset{data: %Shape{}}
+
+  """
+  def change_shape(%Shape{} = shape, attrs \\ %{}) do
+    Shape.changeset(shape, attrs)
+  end
+end

--- a/api/lib/api/design/shape.ex
+++ b/api/lib/api/design/shape.ex
@@ -1,0 +1,21 @@
+defmodule Api.Design.Shape do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "shapes" do
+    field :height, :integer
+    field :width, :integer
+    field :x_position, :integer
+    field :y_position, :integer
+    field :document_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(shape, attrs) do
+    shape
+    |> cast(attrs, [:height, :width, :x_position, :y_position])
+    |> validate_required([:height, :width, :x_position, :y_position])
+  end
+end

--- a/api/lib/api_web/channels/design_socket.ex
+++ b/api/lib/api_web/channels/design_socket.ex
@@ -2,7 +2,6 @@ defmodule ApiWeb.DesignSocket do
   use Phoenix.Socket
 
   ## Channels
-  # channel "room:*", ApiWeb.RoomChannel
   channel "document:*", ApiWeb.DocumentChannel
 
   # Socket params are passed from the client and can

--- a/api/lib/api_web/channels/document_channel.ex
+++ b/api/lib/api_web/channels/document_channel.ex
@@ -15,4 +15,14 @@ defmodule ApiWeb.DocumentChannel do
     {:noreply, socket}
   end
 
+  def handle_in("shape_movement", %{xMovement: xMovement, yMovement: yMovement}, socket) do
+    broadcast!(socket, "shape_movement", %{xMovement: xMovement, yMovement: yMovement})
+    {:noreply, socket}
+  end
+
+  def handle_in("shape_resize", %{height: height, width: width}, socket) do
+    broadcast!(socket, "shape_resize", %{height: height, width: width})
+    {:noreply, socket}
+  end
+
 end

--- a/api/priv/repo/migrations/20210502170128_create_shapes.exs
+++ b/api/priv/repo/migrations/20210502170128_create_shapes.exs
@@ -1,0 +1,17 @@
+defmodule Api.Repo.Migrations.CreateShapes do
+  use Ecto.Migration
+
+  def change do
+    create table(:shapes) do
+      add :height, :integer
+      add :width, :integer
+      add :x_position, :integer
+      add :y_position, :integer
+      add :document_id, references(:documents, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:shapes, [:document_id])
+  end
+end

--- a/api/test/api/design_test.exs
+++ b/api/test/api/design_test.exs
@@ -120,4 +120,69 @@ defmodule Api.DashboardTest do
       assert %Ecto.Changeset{} = Dashboard.change_document(document)
     end
   end
+
+  describe "shapes" do
+    alias Api.Design.Shape
+
+    @valid_attrs %{height: 42, width: 42, x_position: 42, y_position: 42}
+    @update_attrs %{height: 43, width: 43, x_position: 43, y_position: 43}
+    @invalid_attrs %{height: nil, width: nil, x_position: nil, y_position: nil}
+
+    def shape_fixture(attrs \\ %{}) do
+      {:ok, shape} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Design.create_shape()
+
+      shape
+    end
+
+    test "list_shapes/0 returns all shapes" do
+      shape = shape_fixture()
+      assert Design.list_shapes() == [shape]
+    end
+
+    test "get_shape!/1 returns the shape with given id" do
+      shape = shape_fixture()
+      assert Design.get_shape!(shape.id) == shape
+    end
+
+    test "create_shape/1 with valid data creates a shape" do
+      assert {:ok, %Shape{} = shape} = Design.create_shape(@valid_attrs)
+      assert shape.height == 42
+      assert shape.width == 42
+      assert shape.x_position == 42
+      assert shape.y_position == 42
+    end
+
+    test "create_shape/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Design.create_shape(@invalid_attrs)
+    end
+
+    test "update_shape/2 with valid data updates the shape" do
+      shape = shape_fixture()
+      assert {:ok, %Shape{} = shape} = Design.update_shape(shape, @update_attrs)
+      assert shape.height == 43
+      assert shape.width == 43
+      assert shape.x_position == 43
+      assert shape.y_position == 43
+    end
+
+    test "update_shape/2 with invalid data returns error changeset" do
+      shape = shape_fixture()
+      assert {:error, %Ecto.Changeset{}} = Design.update_shape(shape, @invalid_attrs)
+      assert shape == Design.get_shape!(shape.id)
+    end
+
+    test "delete_shape/1 deletes the shape" do
+      shape = shape_fixture()
+      assert {:ok, %Shape{}} = Design.delete_shape(shape)
+      assert_raise Ecto.NoResultsError, fn -> Design.get_shape!(shape.id) end
+    end
+
+    test "change_shape/1 returns a shape changeset" do
+      shape = shape_fixture()
+      assert %Ecto.Changeset{} = Design.change_shape(shape)
+    end
+  end
 end

--- a/frontend/src/components/DesignContainer.tsx
+++ b/frontend/src/components/DesignContainer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import Shape from "../classes/shape";
 import {DesignPage} from "../pages/DesignPage";
 import { logout, reqAuthToken } from "../services/http_api_service";
-import { connectToDocument, subscribeToRectanlge, sendRectangle } from "../services/ws_api_service";
+import { connectToDocument, subscribeToShape, sendRectangle } from "../services/ws_api_service";
 
 export default function DesignContainer(props: DesignContainerProps) {
 
@@ -28,7 +28,7 @@ export default function DesignContainer(props: DesignContainerProps) {
 
     useEffect(() => {
         if(channel !== undefined) {
-            subscribeToRectanlge(channel, setShapes);
+            subscribeToShape(channel, setShapes);
         }
     }, [channel]);
 

--- a/frontend/src/services/ws_api_service.ts
+++ b/frontend/src/services/ws_api_service.ts
@@ -10,9 +10,17 @@ export function connectToDocument(authToken: string, doc_id: number, ok_fn: Reac
     ok_fn(new_channel);
 }
 
-export function subscribeToRectanlge(channel: Channel | undefined, ok_fn: React.Dispatch<React.SetStateAction<Shape[]>>) {
+export function subscribeToShape(channel: Channel | undefined, ok_fn: React.Dispatch<React.SetStateAction<Shape[]>>) {
     channel?.on("new_rectangle", () => {
         ok_fn(prevShapes => [...prevShapes, new Shape(1, 0, 0, 50, 100)]);
+    });
+
+    channel?.on("shape_resize", () => {
+
+    });
+
+    channel?.on("shape_movement", () => {
+        
     });
 }
 


### PR DESCRIPTION
Implement shape_key assigned on the server. Should be when the shape is added to db. Shape should be stored with whatever attributes it needs and related to the document it belongs to

** create shape model and migration
** shape will have height, width, xPos, yPos, document_id