### PR TITLE
implemented unmounting in design container

### DIFF
--- a/frontend/src/pages/DesignPage.tsx
+++ b/frontend/src/pages/DesignPage.tsx
@@ -49,7 +49,7 @@ interface DesignPageProps {
     shapes: Array<Shape>,
     docId: number,
     mouseDown: boolean,
-    canvas: React.MutableRefObject<HTMLCanvasElement>,
+    canvas: React.MutableRefObject<HTMLCanvasElement | null>,
     
     logout: (ok_fn: React.Dispatch<React.SetStateAction<boolean>>) => void,
     setAuthenticated: React.Dispatch<React.SetStateAction<boolean>>,

--- a/frontend/src/services/design_service.ts
+++ b/frontend/src/services/design_service.ts
@@ -2,9 +2,9 @@ import { Channel } from "phoenix";
 import React from "react";
 import Shape from "../classes/shape";
 
-export function newShape(canvas: React.MutableRefObject<HTMLCanvasElement>, shape: Shape) {
-    const context = canvas.current.getContext("2d");
-    if(context !== null) {
+export function newShape(canvas: React.MutableRefObject<HTMLCanvasElement | null>, shape: Shape) {
+    const context = canvas.current?.getContext("2d");
+    if(context !== null && context !== undefined) {
         context.beginPath();
         context.fillStyle = "black";
         context.rect(shape.position_x, shape.position_y, shape.width, shape.height);

--- a/frontend/src/services/ws_api_service.ts
+++ b/frontend/src/services/ws_api_service.ts
@@ -2,12 +2,18 @@ import {Channel, Socket} from 'phoenix';
 import React from 'react';
 import Shape from '../classes/shape';
 
-export function connectToDocumentChannel(authToken: string, doc_id: number, ok_fn: React.Dispatch<React.SetStateAction<Channel | undefined>>) {
+export function connectToDocumentChannel(authToken: string, doc_id: number, ok_fn_channel: React.Dispatch<React.SetStateAction<Channel | undefined>>, ok_fn_socket: React.Dispatch<React.SetStateAction<Socket | undefined>>) {
     var socket = new Socket('ws://localhost:4000/socket', {params: {authToken: authToken}});
     socket.connect();
     var new_channel = socket.channel('document:'+doc_id, {authToken: authToken});
     new_channel.join();
-    ok_fn(new_channel);
+    ok_fn_channel(new_channel);
+    ok_fn_socket(socket);
+}
+
+export function disconnectFromDocumentChannel(channel: Channel | undefined, socket: Socket | undefined) {
+    channel?.leave();
+    socket?.disconnect();
 }
 
 export function newShapeFromChannel(channel: Channel | undefined, ok_fn: React.Dispatch<React.SetStateAction<Shape[]>>) {


### PR DESCRIPTION
Fix issue with reconnecting to web socket after loading doc, going to dashboard, then back into doc.

Implement Socket and channel disconnect on unmount of design container.